### PR TITLE
Clean shutdown

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -6,9 +6,14 @@ hostname = require('os').hostname()
 
 buildKey = (key)-> "#{name}.#{hostname}.#{key}"
 
+destructors = []
+
 module.exports =
 	initialize: (_name) ->
 		name = _name
+
+	registerDestructor: (func) ->
+		destructors.push func
 
 	set : (key, value, sampleRate = 1)->
 		statsd.set buildKey(key), value, sampleRate
@@ -35,3 +40,7 @@ module.exports =
 	http: require "./http"
 	open_sockets: require "./open_sockets"
 
+	close: () ->
+		for func in destructors
+			func()
+		statsd.close()

--- a/open_sockets.coffee
+++ b/open_sockets.coffee
@@ -3,9 +3,12 @@ seconds = 1000
 
 module.exports = OpenSocketsMonitor =
 	monitor: (logger) ->
-		setInterval () ->
+		interval = setInterval () ->
 			OpenSocketsMonitor.gaugeOpenSockets()
 		, 5 * seconds
+		Metrics = require "./metrics"
+		Metrics.registerDestructor () ->
+			clearInterval(interval)
 
 	gaugeOpenSockets: () ->
 		Metrics = require "./metrics"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
provide support for destructors (to cancel interval timer in open_sockets module)
and add a close() method to shutdown the connection to statsd.
