### PR TITLE
make statsd host/port configurable

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -1,5 +1,8 @@
 StatsD = require('lynx')
-statsd = new StatsD('localhost', 8125, {on_error:->})
+Settings = require('settings-sharelatex')
+statsd = new StatsD(Settings.metrics?.statsd?.host or "localhost",
+                    Settings.metrics?.statsd?.port or 8125,
+                    {on_error:->})
 
 name = "unknown"
 hostname = require('os').hostname()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "lynx": "~0.1.1",
     "coffee-script": "1.6.0",
-    "underscore": "~1.6.0"
+    "underscore": "~1.6.0",
+    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0"
   }
 }


### PR DESCRIPTION
Your choice, if you want "settings-sharelatex" part of this module.
I currently use your project in a research project related to autoscaling
microservices. We have packaged each component in a seperated 
container and want the application metrics in a single place.
