### PR TITLE
handle undefined logger in event loop monitor

### DIFF
--- a/event_loop.coffee
+++ b/event_loop.coffee
@@ -1,7 +1,9 @@
 module.exports = EventLoopMonitor =
 	monitor: (logger, interval = 1000, log_threshold = 100) ->
 		Metrics = require "./metrics"
-		
+		# check for logger on startup to avoid exceptions later if undefined
+		throw new Error("logger is undefined") if !logger?
+		# monitor delay in setInterval to detect event loop blocking
 		previous = Date.now()
 		intervalId = setInterval () ->
 			now = Date.now()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",

--- a/test/unit/coffee/event_loop.coffee
+++ b/test/unit/coffee/event_loop.coffee
@@ -1,0 +1,34 @@
+require('coffee-script')
+chai = require('chai')
+should = chai.should()
+expect = chai.expect
+path = require('path')
+modulePath = path.join __dirname, '../../../event_loop.coffee'
+SandboxedModule = require('sandboxed-module')
+sinon = require("sinon")
+
+describe 'event_loop', ->
+
+	before ->
+		@metrics = {
+			timing: sinon.stub()
+			registerDestructor: sinon.stub()
+		}
+		@logger = {
+			warn: sinon.stub()
+		}
+		@event_loop = SandboxedModule.require modulePath, requires:
+			'./metrics': @metrics
+
+	describe 'with a logger provided', ->
+		before  ->
+			@event_loop.monitor(@logger)
+
+		it 'should register a destructor with metrics', ->
+			@metrics.registerDestructor.called.should.equal true
+
+	describe 'without a logger provided', ->
+		
+		it 'should throw an exception', ->
+			expect(@event_loop.monitor).to.throw('logger is undefined')
+


### PR DESCRIPTION
check for the logger being undefined at startup to avoid an crashing with exception later when we log a slow event loop.

also bumps version to 1.7.2