### PR TITLE
allow a global gauge not specific to a host

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -5,6 +5,7 @@ name = "unknown"
 hostname = require('os').hostname()
 
 buildKey = (key)-> "#{name}.#{hostname}.#{key}"
+buildGlobalKey = (key)-> "#{name}.global.#{key}"
 
 destructors = []
 
@@ -41,6 +42,9 @@ module.exports = Metrics =
 
 	gauge : (key, value, sampleRate = 1)->
 		statsd.gauge buildKey(key), value, sampleRate
+
+	globalGauge: (key, value, sampleRate = 1)->
+		statsd.gauge buildGlobalKey(key), value, sampleRate
 
 	mongodb: require "./mongodb"
 	http: require "./http"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently the metrics include the host in the key.  I needed to record a gauge like 'number of active queues' which is not specific to a host. 

I thought I would be able to access the most recent value across a set of hosts using graphite functions but it's not possible (because gauges always have a value, so there is no concept of the most recent data point across a set).

This changes add a `globalGauge` metric which records the same data is `gauge` but with a key of `service.global.foo' instead of `service.hostname.foo`.