### PR TITLE
metrics 2.0.13

### DIFF
--- a/metrics.coffee
+++ b/metrics.coffee
@@ -1,5 +1,5 @@
 prom = require('prom-client')
-Register = require('prom-client').register
+
 collectDefaultMetrics = prom.collectDefaultMetrics
 
 appname = "unknown"
@@ -15,6 +15,7 @@ destructors = []
 require "./uv_threadpool_size"
 
 module.exports = Metrics =
+	register: require('prom-client').register
 	initialize: (_name) ->
 		appname = _name
 		collectDefaultMetrics({ timeout: 5000, prefix: Metrics.buildPromKey()})
@@ -60,8 +61,8 @@ module.exports = Metrics =
 
 	injectMetricsRoute: (app) ->
 		app.get('/metrics', (req, res) -> 
-			res.set('Content-Type', Register.contentType)
-			res.end(Register.metrics())
+			res.set('Content-Type', register.contentType)
+			res.end(register.metrics())
 		)
 
 	buildPromKey: (key = "")->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-sharelatex",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "A drop-in metrics and monitoring module for node.js apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:

* Make register public to enable support for servers other than Express (e.g. hapi).